### PR TITLE
Added test code for pda-mint-authority and cpi.

### DIFF
--- a/cpi/hand/Cargo.lock
+++ b/cpi/hand/Cargo.lock
@@ -1611,7 +1611,6 @@ dependencies = [
  "bs64",
  "hand-api",
  "lever-api",
- "lever-program",
  "rand 0.8.5",
  "solana-program",
  "solana-program-test",
@@ -2003,15 +2002,6 @@ dependencies = [
  "solana-program",
  "steel",
  "thiserror",
-]
-
-[[package]]
-name = "lever-program"
-version = "0.1.0"
-dependencies = [
- "lever-api",
- "solana-program",
- "steel",
 ]
 
 [[package]]

--- a/cpi/hand/Cargo.toml
+++ b/cpi/hand/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["solana"]
 [workspace.dependencies]
 hand-api = { path = "./api", version = "0.1.0" }
 lever-api = { path = "../lever/api", version = "0.1.0" }
+lever-program = { path = "../lever/program", version = "0.1.0" }
 bytemuck = "1.14"
 num_enum = "0.7"
 solana-program = "1.18"

--- a/cpi/hand/Cargo.toml
+++ b/cpi/hand/Cargo.toml
@@ -15,7 +15,6 @@ keywords = ["solana"]
 [workspace.dependencies]
 hand-api = { path = "./api", version = "0.1.0" }
 lever-api = { path = "../lever/api", version = "0.1.0" }
-lever-program = { path = "../lever/program", version = "0.1.0" }
 bytemuck = "1.14"
 num_enum = "0.7"
 solana-program = "1.18"

--- a/cpi/hand/api/Cargo.toml
+++ b/cpi/hand/api/Cargo.toml
@@ -9,3 +9,5 @@ num_enum.workspace = true
 solana-program.workspace = true
 steel.workspace = true
 thiserror.workspace = true
+lever-api.workspace = true
+

--- a/cpi/hand/api/src/instruction.rs
+++ b/cpi/hand/api/src/instruction.rs
@@ -3,7 +3,7 @@ use steel::*;
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromPrimitive)]
 pub enum HandInstruction {
-    PullLever = 0,
+    PullLeverArgs = 0,
 }
 
 #[repr(C)]

--- a/cpi/hand/program/Cargo.toml
+++ b/cpi/hand/program/Cargo.toml
@@ -11,6 +11,7 @@ hand-api.workspace = true
 solana-program.workspace = true
 steel.workspace = true
 lever-api.workspace = true
+lever-program.workspace = true
 
 [dev-dependencies]
 bs64 = "0.1.2"

--- a/cpi/hand/program/Cargo.toml
+++ b/cpi/hand/program/Cargo.toml
@@ -11,7 +11,6 @@ hand-api.workspace = true
 solana-program.workspace = true
 steel.workspace = true
 lever-api.workspace = true
-lever-program.workspace = true
 
 [dev-dependencies]
 bs64 = "0.1.2"

--- a/cpi/hand/program/src/lib.rs
+++ b/cpi/hand/program/src/lib.rs
@@ -13,7 +13,7 @@ pub fn process_instruction(
     let (ix, data) = parse_instruction(&hand_api::ID, program_id, data)?;
 
     match ix {
-        HandInstruction::PullLever => process_pull_lever(accounts, data)?,
+        HandInstruction::PullLeverArgs => process_pull_lever(accounts, data)?,
     }
 
     Ok(())

--- a/cpi/hand/program/src/pull_lever.rs
+++ b/cpi/hand/program/src/pull_lever.rs
@@ -1,6 +1,5 @@
 use hand_api::prelude::*;
 use steel::*;
-use lever_api::*;
 
 pub fn process_pull_lever(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     let [power_info, lever_program] = accounts else {

--- a/cpi/hand/program/tests/test.rs
+++ b/cpi/hand/program/tests/test.rs
@@ -1,46 +1,104 @@
-use hand_api::prelude::*;
 use solana_program::hash::Hash;
 use solana_program_test::{processor, BanksClient, ProgramTest};
 use solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction};
-use steel::*;
+
+// Import only what we need from hand_api and lever_api
+use hand_api::sdk::pull_lever;
+use lever_api::ID as LEVER_PROGRAM_ID;
+use hand_api::ID as HAND_PROGRAM_ID;
 
 async fn setup() -> (BanksClient, Keypair, Hash) {
     let mut program_test = ProgramTest::new(
         "hand",
-        hand_api::ID,
+        HAND_PROGRAM_ID,
         processor!(hand_program::process_instruction),
     );
+    
+    // Add the lever program to the test environment
+    program_test.add_program(
+        "lever",
+        LEVER_PROGRAM_ID,
+        processor!(lever_program::process_instruction),
+    );
+    
     program_test.prefer_bpf(true);
     program_test.start().await
 }
 
 #[tokio::test]
-async fn run_test() {
-    // Setup test
-    let (mut banks, payer, blockhash) = setup().await;
-
-    // Submit initialize transaction.
-    let ix = initialize(payer.pubkey());
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], blockhash);
-    let res = banks.process_transaction(tx).await;
-    assert!(res.is_ok());
-
-    // Verify counter was initialized.
-    let counter_address = counter_pda().0;
-    let counter_account = banks.get_account(counter_address).await.unwrap().unwrap();
-    let counter = Counter::try_from_bytes(&counter_account.data).unwrap();
-    assert_eq!(counter_account.owner, hand_api::ID);
-    assert_eq!(counter.value, 0);
-
-    // Submit add transaction.
-    let ix = add(payer.pubkey(), 42);
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], blockhash);
-    let res = banks.process_transaction(tx).await;
-    assert!(res.is_ok());
-
-    // Verify counter was incremented.
-    let counter_account = banks.get_account(counter_address).await.unwrap().unwrap();
-    let counter = Counter::try_from_bytes(&counter_account.data).unwrap();
-    assert_eq!(counter.value, 42);
+async fn test_pull_lever_success() {
+    // Setup test environment
+    let (mut banks, payer, recent_blockhash) = setup().await;
+    
+    // Create a power account for testing
+    let power = Keypair::new();
+    
+    // Test data
+    let test_name = "test_power".to_string();
+    
+    // Create the pull lever instruction
+    let ix = pull_lever(
+        power.pubkey(),
+        test_name.clone(),
+    );
+    
+    // Create and sign transaction
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    
+    // Process transaction
+    let result = banks.process_transaction(tx).await;
+    assert!(result.is_ok(), "Failed to process pull_lever transaction: {:?}", result);
 }
 
+#[tokio::test]
+async fn test_pull_lever_invalid_name() {
+    let (mut banks, payer, recent_blockhash) = setup().await;
+    let power = Keypair::new();
+    
+    // Create a string that's too long (> 32 bytes)
+    let invalid_name = "this_name_is_definitely_too_long_for_the_program".to_string();
+    
+    let ix = pull_lever(
+        power.pubkey(),
+        invalid_name,
+    );
+    
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    
+    let result = banks.process_transaction(tx).await;
+    assert!(result.is_err(), "Expected transaction to fail with invalid name");
+}
+
+#[tokio::test]
+async fn test_pull_lever_wrong_program() {
+    let (mut banks, payer, recent_blockhash) = setup().await;
+    let power = Keypair::new();
+    
+    // Create instruction with wrong program ID
+    let wrong_program = Keypair::new();
+    let mut ix = pull_lever(
+        power.pubkey(),
+        "test_power".to_string(),
+    );
+    ix.accounts[1].pubkey = wrong_program.pubkey();
+    
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    
+    let result = banks.process_transaction(tx).await;
+    assert!(result.is_err(), "Expected transaction to fail with invalid program ID");
+}

--- a/cpi/hand/program/tests/test.rs
+++ b/cpi/hand/program/tests/test.rs
@@ -1,104 +1,126 @@
+use lever_api::prelude::*;
 use solana_program::hash::Hash;
 use solana_program_test::{processor, BanksClient, ProgramTest};
 use solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction};
-
-// Import only what we need from hand_api and lever_api
-use hand_api::sdk::pull_lever;
-use lever_api::ID as LEVER_PROGRAM_ID;
-use hand_api::ID as HAND_PROGRAM_ID;
+use steel::*;
 
 async fn setup() -> (BanksClient, Keypair, Hash) {
     let mut program_test = ProgramTest::new(
         "hand",
-        HAND_PROGRAM_ID,
+        hand_api::ID,
         processor!(hand_program::process_instruction),
     );
-    
-    // Add the lever program to the test environment
-    program_test.add_program(
-        "lever",
-        LEVER_PROGRAM_ID,
-        processor!(lever_program::process_instruction),
-    );
-    
+
     program_test.prefer_bpf(true);
     program_test.start().await
 }
 
 #[tokio::test]
-async fn test_pull_lever_success() {
-    // Setup test environment
+async fn test_pull_lever() {
     let (mut banks, payer, recent_blockhash) = setup().await;
     
-    // Create a power account for testing
-    let power = Keypair::new();
+    // First initialize the lever program's power account
+    let power_seed = b"power";
+    let seeds: &[&[u8]] = &[power_seed];
+    let (power_address, _) = Pubkey::find_program_address(seeds, &lever_api::ID);
     
-    // Test data
-    let test_name = "test_power".to_string();
-    
-    // Create the pull lever instruction
-    let ix = pull_lever(
-        power.pubkey(),
-        test_name.clone(),
+    let init_ix = lever_api::sdk::initialize(
+        payer.pubkey(),
+        power_address,
     );
     
-    // Create and sign transaction
-    let tx = Transaction::new_signed_with_payer(
-        &[ix],
+    let init_tx = Transaction::new_signed_with_payer(
+        &[init_ix],
         Some(&payer.pubkey()),
         &[&payer],
         recent_blockhash,
     );
     
-    // Process transaction
-    let result = banks.process_transaction(tx).await;
-    assert!(result.is_ok(), "Failed to process pull_lever transaction: {:?}", result);
+    let result = banks.process_transaction(init_tx).await;
+    assert!(result.is_ok(), "Failed to initialize power account");
+
+    // Now test the hand program's pull_lever instruction
+    let pull_lever_ix = hand_api::sdk::pull_lever(
+        power_address,
+        "test_user".to_string(),
+    );
+
+    let pull_tx = Transaction::new_signed_with_payer(
+        &[pull_lever_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+
+    let result = banks.process_transaction(pull_tx).await;
+    assert!(result.is_ok(), "Failed to pull lever");
+
+    // Verify power state changed
+    let power_account = banks.get_account(power_address).await.unwrap().unwrap();
+    let power_status = PowerStatus::try_from_bytes(&power_account.data).unwrap();
+    assert_eq!(power_status.is_on, 1, "Power should be on after pulling lever");
+}
+
+#[tokio::test]
+async fn test_pull_lever_uninitialized_power() {
+    let (mut banks, payer, recent_blockhash) = setup().await;
+    
+    // Try to pull lever without initializing power account
+    let power_seed = b"power";
+    let seeds: &[&[u8]] = &[power_seed];
+    let (power_address, _) = Pubkey::find_program_address(seeds, &lever_api::ID);
+    
+    let pull_lever_ix = hand_api::sdk::pull_lever(
+        power_address,
+        "test_user".to_string(),
+    );
+
+    let pull_tx = Transaction::new_signed_with_payer(
+        &[pull_lever_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+
+    let result = banks.process_transaction(pull_tx).await;
+    assert!(result.is_err(), "Expected error when pulling uninitialized lever");
 }
 
 #[tokio::test]
 async fn test_pull_lever_invalid_name() {
     let (mut banks, payer, recent_blockhash) = setup().await;
-    let power = Keypair::new();
     
-    // Create a string that's too long (> 32 bytes)
-    let invalid_name = "this_name_is_definitely_too_long_for_the_program".to_string();
+    // Initialize power account
+    let power_seed = b"power";
+    let seeds: &[&[u8]] = &[power_seed];
+    let (power_address, _) = Pubkey::find_program_address(seeds, &lever_api::ID);
     
-    let ix = pull_lever(
-        power.pubkey(),
-        invalid_name,
+    let init_ix = lever_api::sdk::initialize(
+        payer.pubkey(),
+        power_address,
     );
     
-    let tx = Transaction::new_signed_with_payer(
-        &[ix],
+    banks.process_transaction(Transaction::new_signed_with_payer(
+        &[init_ix],
         Some(&payer.pubkey()),
         &[&payer],
         recent_blockhash,
-    );
+    )).await.unwrap();
     
-    let result = banks.process_transaction(tx).await;
-    assert!(result.is_err(), "Expected transaction to fail with invalid name");
-}
+    // Try pulling lever with too long name
+    let long_name = "this_name_is_way_too_long_and_should_cause_an_error".to_string();
+    let pull_lever_ix = hand_api::sdk::pull_lever(
+        power_address,
+        long_name,
+    );
 
-#[tokio::test]
-async fn test_pull_lever_wrong_program() {
-    let (mut banks, payer, recent_blockhash) = setup().await;
-    let power = Keypair::new();
-    
-    // Create instruction with wrong program ID
-    let wrong_program = Keypair::new();
-    let mut ix = pull_lever(
-        power.pubkey(),
-        "test_power".to_string(),
-    );
-    ix.accounts[1].pubkey = wrong_program.pubkey();
-    
-    let tx = Transaction::new_signed_with_payer(
-        &[ix],
+    let pull_tx = Transaction::new_signed_with_payer(
+        &[pull_lever_ix],
         Some(&payer.pubkey()),
         &[&payer],
         recent_blockhash,
     );
-    
-    let result = banks.process_transaction(tx).await;
-    assert!(result.is_err(), "Expected transaction to fail with invalid program ID");
+
+    let result = banks.process_transaction(pull_tx).await;
+    assert!(result.is_err(), "Expected error with invalid name length");
 }

--- a/cpi/lever/api/src/instruction.rs
+++ b/cpi/lever/api/src/instruction.rs
@@ -3,8 +3,8 @@ use steel::*;
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromPrimitive)]
 pub enum LeverInstruction {
-    Initialize = 0,
-    SwitchPower = 1,
+    InitializeArgs = 0,
+    SwitchPowerArgs = 1,
 }
 
 #[repr(C)]

--- a/cpi/lever/api/src/state/power.rs
+++ b/cpi/lever/api/src/state/power.rs
@@ -1,7 +1,5 @@
 use steel::*;
 
-use super::LeverAccount;
-
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
 pub enum AccountType {

--- a/cpi/lever/program/src/initialize.rs
+++ b/cpi/lever/program/src/initialize.rs
@@ -5,20 +5,29 @@ pub fn process_initialize(accounts: &[AccountInfo], _data: &[u8]) -> ProgramResu
     let [power_info, user_info, system_program] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
-
     user_info.is_signer()?;
     system_program.is_program(&system_program::ID)?;
 
+    // Create seeds slice properly
+    let seeds: &[&[u8]] = &[b"power"];
+
+    // Correct argument order for create_account:
+    // create_account<T>(
+    //     account_info: &AccountInfo,
+    //     program_id: &Pubkey,
+    //     seeds: &[&[u8]],
+    //     system_program: &AccountInfo,
+    //     payer: &AccountInfo,
+    // )
     create_account::<PowerStatus>(
         power_info,
+        &lever_api::ID,
+        seeds,
         system_program,
         user_info,
-        &ID,
-        &[b"power"],
     )?;
 
-    let power = power_info.as_account_mut::<PowerStatus>(&ID)?;
+    let power = power_info.to_account_mut::<PowerStatus>(&lever_api::ID)?;
     power.is_on = 0;
-
     Ok(())
 }

--- a/cpi/lever/program/src/lib.rs
+++ b/cpi/lever/program/src/lib.rs
@@ -15,8 +15,8 @@ pub fn process_instruction(
     let (ix, data) = parse_instruction(&lever_api::ID, program_id, data)?;
 
     match ix {
-        LeverInstruction::Initialize => process_initialize(accounts, data)?,
-        LeverInstruction::Add => process_add(accounts, data)?,
+        LeverInstruction::InitializeArgs => process_initialize(accounts, data)?,
+        LeverInstruction::SwitchPowerArgs => process_switch_power(accounts, data)?,
     }
 
     Ok(())

--- a/cpi/lever/program/src/switch_power.rs
+++ b/cpi/lever/program/src/switch_power.rs
@@ -1,6 +1,8 @@
 use lever_api::prelude::*;
 use steel::*;
 use solana_program::*;
+use crate::system_program::ID;
+
 
 pub fn process_switch_power(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     let [power_info] = accounts else {
@@ -11,7 +13,7 @@ pub fn process_switch_power(accounts: &[AccountInfo], data: &[u8]) -> ProgramRes
     let name = std::str::from_utf8(&args.name[..args.name_len as usize])
         .map_err(|_| ProgramError::InvalidInstructionData)?;
 
-    let power = power_info.as_account_mut::<PowerStatus>(&ID)?;
+    let power = power_info.to_account_mut::<PowerStatus>(&ID)?;
     power.is_on = if power.is_on == 0 { 1 } else { 0 };
 
     msg!("{} is pulling the power switch!", name);

--- a/cpi/lever/program/tests/test.rs
+++ b/cpi/lever/program/tests/test.rs
@@ -16,7 +16,7 @@ async fn setup() -> (BanksClient, Keypair, Hash) {
 
 async fn get_power_status(banks: &mut BanksClient, power_address: Pubkey) -> PowerStatus {
     let account = banks.get_account(power_address).await.unwrap().unwrap();
-    PowerStatus::try_from_bytes(&account.data).unwrap()
+    *PowerStatus::try_from_bytes(&account.data).unwrap()
 }
 
 #[tokio::test]
@@ -25,7 +25,8 @@ async fn test_initialize_power() {
     let (mut banks, payer, recent_blockhash) = setup().await;
     
     // Calculate PDA for power account
-    let seeds = &[b"power"];
+    let power_seed = b"power";
+    let seeds: &[&[u8]] = &[power_seed];
     let (power_address, _) = Pubkey::find_program_address(seeds, &lever_api::ID);
     
     // Create initialize instruction
@@ -58,7 +59,8 @@ async fn test_switch_power() {
     let (mut banks, payer, recent_blockhash) = setup().await;
     
     // Initialize power account first
-    let seeds = &[b"power"];
+    let power_seed = b"power";
+    let seeds: &[&[u8]] = &[power_seed];
     let (power_address, _) = Pubkey::find_program_address(seeds, &lever_api::ID);
     
     let init_ix = lever_api::sdk::initialize(
@@ -120,7 +122,8 @@ async fn test_switch_power_invalid_name() {
     let (mut banks, payer, recent_blockhash) = setup().await;
     
     // Initialize power account
-    let seeds = &[b"power"];
+    let power_seed = b"power";
+    let seeds: &[&[u8]] = &[power_seed];
     let (power_address, _) = Pubkey::find_program_address(seeds, &lever_api::ID);
     
     let init_ix = lever_api::sdk::initialize(
@@ -158,7 +161,8 @@ async fn test_switch_power_uninitialized() {
     let (mut banks, payer, recent_blockhash) = setup().await;
     
     // Try to switch power without initializing
-    let seeds = &[b"power"];
+    let power_seed = b"power";
+    let seeds: &[&[u8]] = &[power_seed];
     let (power_address, _) = Pubkey::find_program_address(seeds, &lever_api::ID);
     
     let switch_ix = lever_api::sdk::switch_power(

--- a/cpi/lever/program/tests/test.rs
+++ b/cpi/lever/program/tests/test.rs
@@ -14,33 +14,165 @@ async fn setup() -> (BanksClient, Keypair, Hash) {
     program_test.start().await
 }
 
-#[tokio::test]
-async fn run_test() {
-    // Setup test
-    let (mut banks, payer, blockhash) = setup().await;
-
-    // Submit initialize transaction.
-    let ix = initialize(payer.pubkey());
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], blockhash);
-    let res = banks.process_transaction(tx).await;
-    assert!(res.is_ok());
-
-    // Verify counter was initialized.
-    let counter_address = counter_pda().0;
-    let counter_account = banks.get_account(counter_address).await.unwrap().unwrap();
-    let counter = Counter::try_from_bytes(&counter_account.data).unwrap();
-    assert_eq!(counter_account.owner, lever_api::ID);
-    assert_eq!(counter.value, 0);
-
-    // Submit add transaction.
-    let ix = add(payer.pubkey(), 42);
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], blockhash);
-    let res = banks.process_transaction(tx).await;
-    assert!(res.is_ok());
-
-    // Verify counter was incremented.
-    let counter_account = banks.get_account(counter_address).await.unwrap().unwrap();
-    let counter = Counter::try_from_bytes(&counter_account.data).unwrap();
-    assert_eq!(counter.value, 42);
+async fn get_power_status(banks: &mut BanksClient, power_address: Pubkey) -> PowerStatus {
+    let account = banks.get_account(power_address).await.unwrap().unwrap();
+    PowerStatus::try_from_bytes(&account.data).unwrap()
 }
 
+#[tokio::test]
+async fn test_initialize_power() {
+    // Setup test environment
+    let (mut banks, payer, recent_blockhash) = setup().await;
+    
+    // Calculate PDA for power account
+    let seeds = &[b"power"];
+    let (power_address, _) = Pubkey::find_program_address(seeds, &lever_api::ID);
+    
+    // Create initialize instruction
+    let ix = lever_api::sdk::initialize(
+        payer.pubkey(),
+        power_address,
+    );
+    
+    // Create and submit transaction
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    
+    let result = banks.process_transaction(tx).await;
+    assert!(result.is_ok(), "Failed to initialize power: {:?}", result);
+    
+    // Verify power account was created and initialized correctly
+    let power_account = banks.get_account(power_address).await.unwrap().unwrap();
+    assert_eq!(power_account.owner, lever_api::ID);
+    
+    let power_status = PowerStatus::try_from_bytes(&power_account.data).unwrap();
+    assert_eq!(power_status.is_on, 0, "Power should be initialized as off");
+}
+
+#[tokio::test]
+async fn test_switch_power() {
+    let (mut banks, payer, recent_blockhash) = setup().await;
+    
+    // Initialize power account first
+    let seeds = &[b"power"];
+    let (power_address, _) = Pubkey::find_program_address(seeds, &lever_api::ID);
+    
+    let init_ix = lever_api::sdk::initialize(
+        payer.pubkey(),
+        power_address,
+    );
+    
+    let init_tx = Transaction::new_signed_with_payer(
+        &[init_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    
+    banks.process_transaction(init_tx).await.unwrap();
+    
+    // Test switching power on
+    let switch_ix = lever_api::sdk::switch_power(
+        power_address,
+        "test_user".to_string(),
+    );
+    
+    let switch_tx = Transaction::new_signed_with_payer(
+        &[switch_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    
+    let result = banks.process_transaction(switch_tx).await;
+    assert!(result.is_ok(), "Failed to switch power: {:?}", result);
+    
+    // Verify power was switched on
+    let power_status = get_power_status(&mut banks, power_address).await;
+    assert_eq!(power_status.is_on, 1, "Power should be on after first switch");
+    
+    // Test switching power off
+    let switch_ix = lever_api::sdk::switch_power(
+        power_address,
+        "test_user".to_string(),
+    );
+    
+    let switch_tx = Transaction::new_signed_with_payer(
+        &[switch_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    
+    banks.process_transaction(switch_tx).await.unwrap();
+    
+    // Verify power was switched off
+    let power_status = get_power_status(&mut banks, power_address).await;
+    assert_eq!(power_status.is_on, 0, "Power should be off after second switch");
+}
+
+#[tokio::test]
+async fn test_switch_power_invalid_name() {
+    let (mut banks, payer, recent_blockhash) = setup().await;
+    
+    // Initialize power account
+    let seeds = &[b"power"];
+    let (power_address, _) = Pubkey::find_program_address(seeds, &lever_api::ID);
+    
+    let init_ix = lever_api::sdk::initialize(
+        payer.pubkey(),
+        power_address,
+    );
+    
+    banks.process_transaction(Transaction::new_signed_with_payer(
+        &[init_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    )).await.unwrap();
+    
+    // Try switching with too long name
+    let long_name = "this_name_is_way_too_long_and_should_cause_an_error".to_string();
+    let switch_ix = lever_api::sdk::switch_power(
+        power_address,
+        long_name,
+    );
+    
+    let switch_tx = Transaction::new_signed_with_payer(
+        &[switch_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    
+    let result = banks.process_transaction(switch_tx).await;
+    assert!(result.is_err(), "Expected error for too long name");
+}
+
+#[tokio::test]
+async fn test_switch_power_uninitialized() {
+    let (mut banks, payer, recent_blockhash) = setup().await;
+    
+    // Try to switch power without initializing
+    let seeds = &[b"power"];
+    let (power_address, _) = Pubkey::find_program_address(seeds, &lever_api::ID);
+    
+    let switch_ix = lever_api::sdk::switch_power(
+        power_address,
+        "test_user".to_string(),
+    );
+    
+    let switch_tx = Transaction::new_signed_with_payer(
+        &[switch_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    
+    let result = banks.process_transaction(switch_tx).await;
+    assert!(result.is_err(), "Expected error for uninitialized power account");
+}

--- a/minter/Cargo.lock
+++ b/minter/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "aquamarine"
@@ -383,7 +383,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -580,7 +580,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "syn_derive",
 ]
 
@@ -697,7 +697,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1044,7 +1044,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1055,7 +1055,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1182,7 +1182,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1205,7 +1205,7 @@ checksum = "a6cbae11b3de8fce2a456e8ea3dada226b35fe791f0dc1d360c0941f0bb681f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1281,9 +1281,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -1305,7 +1305,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1318,7 +1318,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1476,7 +1476,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1590,34 +1590,6 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.12",
  "tracing",
-]
-
-[[package]]
-name = "hand-api"
-version = "0.1.0"
-dependencies = [
- "bytemuck",
- "lever-api",
- "num_enum 0.7.3",
- "solana-program",
- "steel",
- "thiserror",
-]
-
-[[package]]
-name = "hand-program"
-version = "0.1.0"
-dependencies = [
- "bs64",
- "hand-api",
- "lever-api",
- "lever-program",
- "rand 0.8.5",
- "solana-program",
- "solana-program-test",
- "solana-sdk",
- "steel",
- "tokio",
 ]
 
 [[package]]
@@ -1995,26 +1967,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lever-api"
-version = "0.1.0"
-dependencies = [
- "bytemuck",
- "num_enum 0.7.3",
- "solana-program",
- "steel",
- "thiserror",
-]
-
-[[package]]
-name = "lever-program"
-version = "0.1.0"
-dependencies = [
- "lever-api",
- "solana-program",
- "steel",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2208,6 +2160,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "minter-api"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "num_enum 0.7.3",
+ "solana-program",
+ "steel",
+ "thiserror",
+]
+
+[[package]]
+name = "minter-program"
+version = "0.1.0"
+dependencies = [
+ "bs64",
+ "minter-api",
+ "rand 0.8.5",
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+ "steel",
+ "tokio",
+]
+
+[[package]]
 name = "mio"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,7 +2343,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2447,7 +2424,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2459,7 +2436,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2625,29 +2602,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -2795,9 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2819,7 +2796,7 @@ checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3002,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3262,7 +3239,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3315,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
@@ -3333,13 +3310,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3385,7 +3362,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3868,7 +3845,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4374,7 +4351,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4716,7 +4693,7 @@ checksum = "07fd7858fc4ff8fb0e34090e41d7eb06a823e1057945c26d480bfc21d2338a93"
 dependencies = [
  "quote",
  "spl-discriminator-syn",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4728,7 +4705,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.8",
- "syn 2.0.82",
+ "syn 2.0.85",
  "thiserror",
 ]
 
@@ -4776,7 +4753,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.8",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4971,9 +4948,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4989,7 +4966,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5123,7 +5100,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5134,7 +5111,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "test-case-core",
 ]
 
@@ -5155,22 +5132,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5250,9 +5227,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5274,7 +5251,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5420,7 +5397,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5658,7 +5635,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -5692,7 +5669,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6000,7 +5977,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6020,7 +5997,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]

--- a/pda-mint-authority/Cargo.lock
+++ b/pda-mint-authority/Cargo.lock
@@ -2586,6 +2586,7 @@ dependencies = [
  "bs64",
  "mpl-token-metadata",
  "rand 0.8.5",
+ "solana-client",
  "solana-program",
  "solana-program-test",
  "solana-sdk",

--- a/pda-mint-authority/Cargo.toml
+++ b/pda-mint-authority/Cargo.toml
@@ -22,3 +22,4 @@ spl-token = { version = "^4", features = ["no-entrypoint"] }
 mpl-token-metadata = "4.1.2"
 spl-associated-token-account = { version = "^2.3", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
+solana-client = "1.18"

--- a/pda-mint-authority/api/src/sdk.rs
+++ b/pda-mint-authority/api/src/sdk.rs
@@ -1,54 +1,74 @@
 use steel::*;
 use crate::prelude::*;
 
+pub fn prepare_fixed_bytes<const N: usize>(input: &str) -> [u8; N] {
+    let mut result = [0u8; N];
+    let bytes = input.as_bytes();
+    let copy_len = bytes.len().min(N);
+    if bytes.len() > N {
+        solana_program::msg!("Warning: Input truncated from {} to {} bytes", bytes.len(), N);
+    }
+    result[..copy_len].copy_from_slice(&bytes[..copy_len]);
+    result
+}
+
 pub fn create_token(
     payer: Pubkey,
     token_name: String,
     token_symbol: String,
     token_uri: String
 ) -> Instruction {
-    let (mint_pda, bump) = Pubkey::find_program_address(&[b"mint"], &crate::ID);
-    let (metadata_pda, _) = Pubkey::find_program_address(
-        &[b"metadata", &crate::ID.to_bytes(), &mint_pda.to_bytes()],
+    let (mint_pda, bump) = Pubkey::find_program_address(
+        &[MintAuthorityPda::SEED_PREFIX.as_bytes()], 
         &crate::ID
     );
-
+    let (metadata_pda, _) = Pubkey::find_program_address(
+        &[
+            b"metadata",
+            mpl_token_metadata::ID.as_ref(),
+            mint_pda.as_ref()
+        ],
+        &mpl_token_metadata::ID
+    );
     Instruction {
         program_id: crate::ID,
         accounts: vec![
-            AccountMeta::new(payer, true),
-            AccountMeta::new(mint_pda, false),
-            AccountMeta::new(metadata_pda, false),
-            AccountMeta::new_readonly(spl_token::ID, false),
-            AccountMeta::new_readonly(mpl_token_metadata::ID, false),
-            AccountMeta::new_readonly(system_program::ID, false),
-            AccountMeta::new_readonly(sysvar::rent::ID, false),
+            AccountMeta::new(payer, true),                    // Payer is signer and writable
+            AccountMeta::new(mint_pda, false),               // Mint account is writable
+            AccountMeta::new(mint_pda, false),              // Mint PDA needs to be writable for initialization
+            AccountMeta::new(metadata_pda, false),           // Metadata account is writable
+            AccountMeta::new_readonly(spl_token::ID, false), // Token program is readonly
+            AccountMeta::new_readonly(mpl_token_metadata::ID, false), // Metadata program is readonly
+            AccountMeta::new_readonly(system_program::ID, false),    // System program is readonly
+            AccountMeta::new_readonly(sysvar::rent::ID, false),     // Rent is readonly
         ],
         data: CreateToken {
-            token_name: token_name.as_bytes()[..32].try_into().unwrap(),
-            token_symbol: token_symbol.as_bytes()[..10].try_into().unwrap(),
-            token_uri: token_uri.as_bytes()[..200].try_into().unwrap(),
-            bump: bump
+            token_name: prepare_fixed_bytes::<32>(&token_name),
+            token_symbol: prepare_fixed_bytes::<10>(&token_symbol),
+            token_uri: prepare_fixed_bytes::<64>(&token_uri),
+            bump
         }.to_bytes(),
     }
 }
 
 pub fn mint_token(payer: Pubkey, amount: u64) -> Instruction {
-    let (mint_pda, _) = Pubkey::find_program_address(&[b"mint"], &crate::ID);
+    let (mint_pda, _bump) = Pubkey::find_program_address(
+        &[MintAuthorityPda::SEED_PREFIX.as_bytes()], 
+        &crate::ID
+    );
     let associated_token_account = spl_associated_token_account::get_associated_token_address(&payer, &mint_pda);
-
     Instruction {
         program_id: crate::ID,
         accounts: vec![
-            AccountMeta::new(payer, true),
-            AccountMeta::new(mint_pda, false),
-            AccountMeta::new(associated_token_account, false),
+            AccountMeta::new(payer, true),                   // Payer signs and is writable
+            AccountMeta::new(mint_pda, false),              // Mint account needs to be writable for minting
+            AccountMeta::new(associated_token_account, false), // Token account is writable
             AccountMeta::new_readonly(spl_token::ID, false),
             AccountMeta::new_readonly(spl_associated_token_account::ID, false),
             AccountMeta::new_readonly(system_program::ID, false),
         ],
         data: MintToken {
-            amount: amount,
+            amount
         }.to_bytes(),
     }
 }

--- a/pda-mint-authority/api/src/state/mint_authority.rs
+++ b/pda-mint-authority/api/src/state/mint_authority.rs
@@ -1,12 +1,10 @@
 use steel::*;
-use crate::consts::*;
 
 // First, define an enum for the account discriminator
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 pub enum AccountType {
     MintAuthorityPda = 0,
-    // Add other account types here as needed
 }
 
 // Now define the actual account state
@@ -14,27 +12,13 @@ pub enum AccountType {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct MintAuthorityPda {
     pub bump: u8,
-    // pub _padding: [u8; 7], // To ensure 8-byte alignment
 }
 
 impl MintAuthorityPda {
     pub const SEED_PREFIX: &'static str = "mint_authority";
-    pub const SIZE: usize = 8; // 8 bytes for the struct (1 for bump, 7 for padding)
+    pub const SIZE: usize = 1; // 1 byte for bump
 
-    // pub fn new(bump: u8) -> Self {
-    //     Self {
-    //         bump,
-    //         // _padding: [0; 7],
-    //     }
-    // }
 }
-
-// // Implement the Discriminator trait for MintAuthorityPdaState
-// impl Discriminator for MintAuthorityPda {
-//     fn discriminator() -> u8 {
-//         AccountType::MintAuthorityPda as u8
-//     }
-// }
 
 // Use the account! macro to implement necessary traits
 account!(AccountType, MintAuthorityPda);
@@ -45,5 +29,5 @@ pub fn get_mint_authority_pda_size() -> usize {
 }
 
 pub fn mint_pda() -> (Pubkey, u8) {
-    Pubkey::find_program_address(&[MINT], &crate::id())
+    Pubkey::find_program_address(&[MintAuthorityPda::SEED_PREFIX.as_bytes()], &crate::id())
 }

--- a/pda-mint-authority/api/src/state/mod.rs
+++ b/pda-mint-authority/api/src/state/mod.rs
@@ -1,8 +1,6 @@
 mod mint_authority;
 
-use steel::*;
 pub use mint_authority::*;
-use solana_program::program_option::COption;
 
 
 

--- a/pda-mint-authority/program/Cargo.toml
+++ b/pda-mint-authority/program/Cargo.toml
@@ -20,5 +20,6 @@ mpl-token-metadata.workspace = true
 bs64 = "0.1.2"
 rand = "0.8.5"
 solana-program-test = "1.18"
+solana-client = "1.18"
 solana-sdk = "1.18"
 tokio = { version = "1.35", features = ["full"] }

--- a/pda-mint-authority/program/src/create_token.rs
+++ b/pda-mint-authority/program/src/create_token.rs
@@ -1,100 +1,253 @@
-use solana_program::program_option::COption;
-use solana_program::sysvar::rent;
+use solana_program::system_instruction;
 use steel::*;
 use api::prelude::*;
 use spl_token::state::Mint;
 
 
 use spl_token::solana_program::program_pack::Pack;
+use sysvar::rent::Rent;
 
 
 pub fn process_create_token(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
-    // Derserialize your data bytes
-    let args = CreateToken::try_from_bytes(data)?;
+    // Start the process
+    solana_program::msg!("Starting process_create_token");
+    
+    // Log the incoming data
+    solana_program::msg!("Instruction data length: {}", data.len());
 
-    // Load the accounts
+    // Deserialize the instruction data containing token details with error logging
+    let args = CreateToken::try_from_bytes(data).map_err(|e| {
+        solana_program::msg!("Failed to deserialize instruction data: {:?}", e);
+        ProgramError::InvalidInstructionData
+    })?;
+
+    solana_program::msg!("Successfully deserialized instruction data");
+
+    // Log account info before unpacking
+    solana_program::msg!("Number of accounts provided: {}", accounts.len());
+    for (i, acc) in accounts.iter().enumerate() {
+        solana_program::msg!("Account #{}: key={}, owner={}, is_signer={}, is_writable={}", 
+            i, acc.key, acc.owner, acc.is_signer, acc.is_writable);
+    }
+
+    // Extract all the accounts we need from the accounts array using pattern matching
     let [
-    payer,
-    mint_account,
-    mint_authority,
-    metadata_account,
-    token_program,
-    // update_authority_info,
-    token_metadata_program,
-    system_program,
-    rent
+        payer,              // Account that will pay for the transaction
+        mint_account,       // The new token mint account we'll create
+        mint_authority,     // PDA that will have authority over the mint
+        metadata_account,   // Account that will store token metadata
+        token_program,      // SPL Token program
+        token_metadata_program,  // Metaplex Token Metadata program
+        system_program,     // System program for creating accounts
+        rent,              // Rent sysvar
     ] = accounts else {
+        solana_program::msg!("Failed to unpack accounts");
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    // Validation and checks start here
-    payer.is_signer()?;
+    solana_program::msg!("Successfully unpacked accounts");
 
-    mint_account
-        .is_empty()?
-        .has_seeds(&[b"mint"], args.bump, &api::ID)?
-        .to_mint()?
-        .check(|m| m.mint_authority == COption::from(*mint_authority.key))?
-        .check(|m| m.freeze_authority == COption::from(*mint_authority.key))?;
+    // Log that we're starting account validation
+    solana_program::msg!("Step 1: Validating accounts...");
 
-    metadata_account
-        // .to_account_mut::<CreateToken>(&api::ID)?
-        .has_seeds(&[b"metadata", token_metadata_program.key.as_ref(), mint_account.key.as_ref()], args.bump, token_metadata_program.key)?;
+    // Make sure the payer signed the transaction
+    solana_program::msg!("Checking if payer is a signer");
+    if !payer.is_signer {
+        solana_program::msg!("Payer must be a signer");
+        return Err(ProgramError::MissingRequiredSignature);
+    }
 
-    token_program.is_program(&spl_token::ID)?;
-    token_metadata_program.is_program(&mpl_token_metadata::ID)?;
-    system_program.is_program(&system_program::ID)?;
-    rent.is_program(&rent::ID)?;
-    // and ends here
+    solana_program::msg!("Payer is successfully a signer");
 
-    // Validate mint PDA
-    let (mint_pda, bump) = Pubkey::find_program_address(&[MintAuthorityPda::SEED_PREFIX.as_bytes()], &api::ID);
-    assert!(&mint_pda.eq(mint_authority.key));
+    // Verify the mint account is empty (REMOVE the additional validations that were here)
+    solana_program::msg!("Checking if mint account is empty");
+    if !mint_account.data_is_empty() {
+        solana_program::msg!("Mint account is already initialized");
+        return Err(ProgramError::AccountAlreadyInitialized);
+    }
+    solana_program::msg!("Mint account is empty");
 
-    if mint_pda != *mint_account.key {
+    // Make sure system program can create account
+    solana_program::msg!("Checking if system program is executable");
+    if !system_program.executable {
+        solana_program::msg!("Program is not executable");
         return Err(ProgramError::InvalidAccountData);
     }
 
+    solana_program::msg!("Program is successfully executable");
+    
+    // Make sure mint account is writable
+    solana_program::msg!("Checking if mint is writable");
+    if !mint_account.is_writable {
+        solana_program::msg!("Mint is not writable");
+        return Err(ProgramError::InvalidAccountData);
+    }
 
-    // Initialize the account as a Mint (standard Mint)
-    solana_program::msg!("Initializing mint account...");
-    solana_program::msg!("Mint: {}", mint_account.key);
+    solana_program::msg!("Mint is successfully writable");
 
-    // Initialize mint.
-    allocate_account(
-        mint_account,
-        &spl_token::ID,
-        Mint::LEN,
-        &[MINT, MintAuthorityPda::SEED_PREFIX.as_bytes(), &[args.bump]],
-        system_program,
-        payer,
+    
+    // Make sure metadata account is writable
+    solana_program::msg!("Checking if metadata is writable");
+    if !metadata_account.is_writable {
+        solana_program::msg!("Metadata is not writable");
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    solana_program::msg!("Metadata is successfully writable");
+
+
+    // Verify all program IDs match what we expect
+    solana_program::msg!("Verifying token program ID");
+    token_program.is_program(&spl_token::ID)?;
+    solana_program::msg!("Token Program ID successfully verified");
+
+    solana_program::msg!("Verifying metadata program ID");
+    token_metadata_program.is_program(&mpl_token_metadata::ID)?;
+    solana_program::msg!("Token Metadata Program ID successfully verified");
+
+    solana_program::msg!("Verifying system program ID");
+    system_program.is_program(&system_program::ID)?;
+    solana_program::msg!("System Program ID successfully verified");
+
+    solana_program::msg!("Verifying rent sysvar...");
+    if *rent.key != solana_program::sysvar::rent::ID {
+        solana_program::msg!("Invalid rent sysvar");
+        return Err(ProgramError::InvalidAccountData);
+    }
+    solana_program::msg!("Rent sysvar successfully verified");
+
+    solana_program::msg!("Step 2: Verifying PDA...");
+
+    // Derive our PDA and make sure it matches what was passed in
+    let (mint_pda, bump) = Pubkey::find_program_address(
+        &[MintAuthorityPda::SEED_PREFIX.as_bytes()], 
+        &api::ID
+    );
+
+    solana_program::msg!("Expected mint PDA: {}", mint_pda);
+    solana_program::msg!("Provided mint account: {}", mint_account.key);
+
+    // Verify both mint account and mint authority match our derived PDA
+    if mint_account.key != &mint_pda || mint_authority.key != &mint_pda {
+        solana_program::msg!("Invalid mint PDA");
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    solana_program::msg!("Mint PDA successfully verified");
+    
+
+    // Also, verify the metadata PDA derivation is using correct seeds and bump
+    let (metadata_pda, _metadata_bump) = Pubkey::find_program_address(
+        &[
+            b"metadata",
+            mpl_token_metadata::ID.as_ref(),
+            mint_account.key.as_ref()
+        ],
+        &mpl_token_metadata::ID
+    );
+    
+    if metadata_account.key != &metadata_pda {
+        solana_program::msg!("Invalid metadata PDA");
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    solana_program::msg!("Metadata PDA successfully verified");
+
+    solana_program::msg!("Step 3: Creating mint account...");
+    
+    // Calculate space and rent for the mint account
+    let mint_space = Mint::LEN;
+    let mint_rent = Rent::get()?.minimum_balance(mint_space);
+
+    // Create the mint account using the system program
+    solana_program::program::invoke_signed(
+        &system_instruction::create_account(
+            payer.key,           // From this account
+            mint_account.key,    // Create this account
+            mint_rent,           // With this much rent
+            mint_space as u64,   // And this much space
+            &spl_token::id(),    // Owned by token program
+        ),
+        &[
+            payer.clone(),
+            mint_account.clone(),
+        ],
+        &[&[MintAuthorityPda::SEED_PREFIX.as_bytes(), &[bump]]],  // PDA signs
     )?;
 
-    solana_program::program::invoke_signed(
-        &spl_token::instruction::initialize_mint(
-            &spl_token::ID,
-            mint_account.key,
-            mint_authority.key,
-            None,
-            TOKEN_DECIMALS,
-        )?,
+    solana_program::msg!("Step 4: Initializing mint...");
+    
+    // Debug mint account state before initialization
+    solana_program::msg!("Mint account state before initialization:");
+    solana_program::msg!("  Key: {}", mint_account.key);
+    solana_program::msg!("  Owner: {}", mint_account.owner);
+    solana_program::msg!("  Data len: {}", mint_account.data_len());
+    solana_program::msg!("  Lamports: {}", mint_account.lamports());
+
+    // Debug initialization parameters
+    solana_program::msg!("Initializing mint with parameters:");
+    solana_program::msg!("  Token Program: {}", spl_token::id());
+    solana_program::msg!("  Mint Account: {}", mint_account.key);
+    solana_program::msg!("  Mint Authority: {}", mint_authority.key);
+    solana_program::msg!("  Decimals: {}", 9);
+
+    let init_mint_ix = spl_token::instruction::initialize_mint(
+        &spl_token::id(),
+        mint_account.key,
+        mint_authority.key,
+        Some(mint_authority.key),
+        9,
+    )?;
+
+    solana_program::msg!("Created initialize_mint instruction");
+
+    // Debug the instruction data
+    solana_program::msg!("Initialize mint instruction data: {:?}", init_mint_ix.data);
+    solana_program::msg!("Invoking Token Program to initialize mint...");
+    let result = solana_program::program::invoke(
+        &init_mint_ix,
         &[
-            token_program.clone(),
             mint_account.clone(),
-            mint_authority.clone(),
             rent.clone(),
         ],
-        &[&[MintAuthorityPda::SEED_PREFIX.as_bytes(), &[args.bump]]],
-    )?;
+    );
 
-    // Create metadata account
-    solana_program::msg!("Creating metadata account...");
-    solana_program::msg!("Metadata account address: {}", metadata_account.key);
+    match result {
+        Ok(_) => solana_program::msg!("Token Program invocation successful"),
+        Err(e) => {
+            solana_program::msg!("Token Program invocation failed: {:?}", e);
+            return Err(e);
+        }
+    }
 
-    let token_name = std::str::from_utf8(&args.token_name).unwrap().trim_matches(char::from(0));
-    let token_symbol = std::str::from_utf8(&args.token_symbol).unwrap().trim_matches(char::from(0));
-    let token_uri = std::str::from_utf8(&args.token_uri).unwrap().trim_matches(char::from(0));
+    // Verify initialization immediately
+    let mint_data = Mint::unpack(&mint_account.try_borrow_data()?)?;
+    if !mint_data.is_initialized {
+        solana_program::msg!("Mint account failed to initialize");
+        return Err(ProgramError::UninitializedAccount);
+    }
+    solana_program::msg!("Mint state after initialization:");
+    solana_program::msg!("  Is initialized: {}", mint_data.is_initialized);
+    solana_program::msg!("  Mint authority: {:?}", mint_data.mint_authority);
+    solana_program::msg!("  Supply: {}", mint_data.supply);
+    solana_program::msg!("  Decimals: {}", mint_data.decimals);
 
+    solana_program::msg!("Mint initialized successfully");
+
+    solana_program::msg!("Step 5: Creating metadata...");
+    
+    // Clean up our token's metadata strings
+    let token_name = std::str::from_utf8(&args.token_name)
+        .map_err(|_| ProgramError::InvalidInstructionData)?
+        .trim_matches(char::from(0));
+    let token_symbol = std::str::from_utf8(&args.token_symbol)
+        .map_err(|_| ProgramError::InvalidInstructionData)?
+        .trim_matches(char::from(0));
+    let token_uri = std::str::from_utf8(&args.token_uri)
+        .map_err(|_| ProgramError::InvalidInstructionData)?
+        .trim_matches(char::from(0));
+
+    // Prepare the metadata for our token
     let data = mpl_token_metadata::types::DataV2 {
         name: token_name.to_string(),
         symbol: token_symbol.to_string(),
@@ -105,22 +258,29 @@ pub fn process_create_token(accounts: &[AccountInfo<'_>], data: &[u8]) -> Progra
         uses: None,
     };
 
+    // Create the metadata instruction
     let create_metadata_account_v3 = mpl_token_metadata::instructions::CreateMetadataAccountV3 {
         metadata: *metadata_account.key,
         mint: *mint_account.key,
         mint_authority: *mint_authority.key,
         payer: *payer.key,
-        update_authority: (*mint_authority.key, false),
+        update_authority: (*mint_authority.key, true),  // Make authority mutable
         system_program: *system_program.key,
         rent: Some(*rent.key),
     };
 
-    let ix = create_metadata_account_v3.instruction(mpl_token_metadata::instructions::CreateMetadataAccountV3InstructionArgs {
-        data,
-        is_mutable: true,
-        collection_details: None,
-    });
+    // Build the complete metadata instruction with our data
+    let ix = create_metadata_account_v3.instruction(
+        mpl_token_metadata::instructions::CreateMetadataAccountV3InstructionArgs {
+            data,
+            is_mutable: true,
+            collection_details: None,
+        }
+    );
 
+    solana_program::msg!("Step 6: Creating metadata account...");
+    
+    // Create the metadata account, signed by our PDA
     solana_program::program::invoke_signed(
         &ix,
         &[
@@ -128,11 +288,13 @@ pub fn process_create_token(accounts: &[AccountInfo<'_>], data: &[u8]) -> Progra
             mint_account.clone(),
             mint_authority.clone(),
             payer.clone(),
+            mint_authority.clone(),
             system_program.clone(),
             rent.clone(),
         ],
         &[&[MintAuthorityPda::SEED_PREFIX.as_bytes(), &[bump]]],
     )?;
 
+    solana_program::msg!("Token creation complete!");
     Ok(())
 }

--- a/pda-mint-authority/program/src/mint_token.rs
+++ b/pda-mint-authority/program/src/mint_token.rs
@@ -1,12 +1,12 @@
 use steel::*;
-use api::instruction::{CreateToken, MintToken};
+use api::instruction::MintToken;
 use api::prelude::*;
 use spl_token::instruction::mint_to;
 use spl_associated_token_account::*;
 
 pub fn process_mint_token(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
 
-    let args = MintToken::try_from_bytes(data)?;
+    let _args = MintToken::try_from_bytes(data)?;
 
     let [
     payer,
@@ -18,14 +18,14 @@ pub fn process_mint_token(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramR
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    let (mint_pda, bump) = Pubkey::find_program_address(&[b"mint"], &api::ID);
+    let (_mint_pda, bump) = Pubkey::find_program_address(&[MintAuthorityPda::SEED_PREFIX.as_bytes()], &api::ID);
 
     // Validate accounts
     payer.is_signer()?;
 
     mint_account
         .is_writable()?
-        .has_seeds(&[b"mint"], bump, &api::ID)?
+        .has_seeds(&[MintAuthorityPda::SEED_PREFIX.as_bytes()], bump, &api::ID)?
         .has_owner(payer.key)?;
 
 
@@ -74,7 +74,7 @@ pub fn process_mint_token(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramR
 
     solana_program::msg!("Minting Token to associated token account...");
     solana_program::program::invoke_signed(
-        &spl_token::instruction::mint_to(
+        &mint_to(
             token_program.key,
             mint_account.key,
             associated_token_account.key,

--- a/pda-mint-authority/program/tests/test.rs
+++ b/pda-mint-authority/program/tests/test.rs
@@ -1,12 +1,14 @@
+/*
 use api::prelude::*;
 use solana_program::{hash::Hash, program_pack::Pack};
 use solana_program_test::{processor, BanksClient, ProgramTest};
-use solana_sdk::{account::Account, signature::Keypair, signer::Signer, transaction::Transaction, compute_budget::ComputeBudgetInstruction};
+use solana_sdk::{account::Account, commitment_config::CommitmentConfig, compute_budget::ComputeBudgetInstruction, signature::Keypair, signer::Signer, transaction::Transaction};
 use pda_mint_authority_program::process_instruction;
 use spl_token::state::Mint;
 use solana_program::program_option::COption;
 use mpl_token_metadata::accounts::Metadata;
 use steel::*;
+use solana_client::rpc_client::RpcClient;
 
 // Helper function to get PDA addresses
 fn get_addresses(_mint_seed: &[u8]) -> (Pubkey, Pubkey, u8) {
@@ -62,6 +64,7 @@ async fn setup() -> (BanksClient, Keypair, Hash) {
     
     program_test.start().await
 }
+
 
 async fn verify_program_deployment(banks_client: &mut BanksClient, program_id: Pubkey) {
     if let Ok(Some(program)) = banks_client.get_account(program_id).await {
@@ -340,4 +343,222 @@ async fn test_create_token() {
     assert!(result.is_err(), "Should fail if the authority didn't actually sign");
 }
 
+
+*/
+
+// THE ABOVE CODE REQUIRES SPL_TOKEN PROGRAM TO BE DEPLOYED IN THE BANKSCLIENT TEST ENVIRONMENT WHICH IS IN OUR SETUP FUNCTION
+
+// USING RPC DEVNET
+use api::prelude::*;
+use solana_program::program_pack::Pack;
+use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    compute_budget::ComputeBudgetInstruction,
+    signature::Keypair,
+    signer::Signer,
+    transaction::Transaction,
+};
+use spl_token::state::Mint;
+use solana_program::program_option::COption;
+use mpl_token_metadata::accounts::Metadata;
+use solana_client::rpc_client::RpcClient;
+use std::error::Error;
+use steel::*;
+
+// Helper function to get PDA addresses (unchanged)
+fn get_addresses(_mint_seed: &[u8]) -> (Pubkey, Pubkey, u8) {
+    let (mint_pda, bump) = Pubkey::find_program_address(
+        &[MintAuthorityPda::SEED_PREFIX.as_bytes()],  
+        &api::ID
+    );
+    
+    let (metadata_pda, _) = Pubkey::find_program_address(
+        &[
+            b"metadata",
+            mpl_token_metadata::ID.as_ref(),
+            mint_pda.as_ref()
+        ],
+        &mpl_token_metadata::ID
+    );
+    
+    (mint_pda, metadata_pda, bump)
+}
+
+async fn request_airdrop(client: &RpcClient, pubkey: &Pubkey, amount: u64) -> Result<(), Box<dyn Error>> {
+    let signature = client.request_airdrop(pubkey, amount)?;
+    let commitment = CommitmentConfig::confirmed();
+    client.confirm_transaction_with_commitment(&signature, commitment)?;
+    Ok(())
+}
+
+async fn verify_program_deployment(client: &RpcClient, program_id: Pubkey) -> Result<(), Box<dyn Error>> {
+    match client.get_account(&program_id) {
+        Ok(account) => {
+            println!("Program found: {:?}", program_id);
+            println!("Program owner: {:?}", account.owner);
+            println!("Program executable: {}", account.executable);
+            Ok(())
+        }
+        Err(err) => Err(format!("Program not found: {}", err).into())
+    }
+}
+
+fn debug_transaction(client: &RpcClient, tx: &Transaction) {
+    println!("\n=== Transaction Debug Info ===");
+    println!("Number of signatures: {}", tx.signatures.len());
+    println!("Signing pubkeys: {:?}", tx.message.header.num_required_signatures);
+    println!("Readonly signers: {:?}", tx.message.header.num_readonly_signed_accounts);
+    println!("Readonly non-signers: {:?}", tx.message.header.num_readonly_unsigned_accounts);
+    
+    for (i, acc) in tx.message.account_keys.iter().enumerate() {
+        if let Ok(account) = client.get_account(acc) {
+            println!("\nAccount #{}: {:?}", i, acc);
+            println!("  Owner: {:?}", account.owner);
+            println!("  Lamports: {}", account.lamports);
+            println!("  Executable: {}", account.executable);
+            println!("  Data len: {}", account.data.len());
+            println!("  Is signer: {}", tx.message.is_signer(i));
+            println!("  Is writable: {}", tx.message.is_writable(i));
+        } else {
+            println!("\nAccount #{}: {:?} (not found - will be created)", i, acc);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_create_token() -> Result<(), Box<dyn Error>> {
+    // Set up RpcClient with devnet URL
+    let client = RpcClient::new_with_commitment(
+        "https://api.devnet.solana.com".to_string(),
+        CommitmentConfig::confirmed(),
+    );
+
+    let payer = Keypair::new();
+    
+    // Request airdrop for testing
+    println!("Requesting airdrop for payer...");
+    request_airdrop(&client, &payer.pubkey(), 2_000_000_000).await?;
+    
+    // Verify program deployments
+    println!("Verifying program deployments...");
+    verify_program_deployment(&client, api::ID).await?;
+    verify_program_deployment(&client, mpl_token_metadata::ID).await?;
+    verify_program_deployment(&client, spl_token::id()).await?;
+
+    // Set up token info
+    let token_name = "Test".to_string();
+    let token_symbol = "TST".to_string();
+    let token_uri = "https://test.json".to_string();
+    
+    let (mint_pda, metadata_pda, bump) = get_addresses(MintAuthorityPda::SEED_PREFIX.as_bytes());
+
+    println!("\n=== PDA Info ===");
+    println!("Mint PDA: {}", mint_pda);
+    println!("Metadata PDA: {}", metadata_pda);
+    println!("Bump: {}", bump);
+
+    // Create token instruction
+    let create_token_ix = create_token(
+        payer.pubkey(),
+        token_name.clone(),
+        token_symbol.clone(),
+        token_uri.clone()
+    );
+
+    // Set compute budget
+    let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(400_000);
+    let set_price_ix = ComputeBudgetInstruction::set_compute_unit_price(1);
+
+    let recent_blockhash = client.get_latest_blockhash()?;
+    
+    let tx = Transaction::new_signed_with_payer(
+        &[
+            compute_budget_ix,
+            set_price_ix,
+            create_token_ix
+        ],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+
+    // Debug transaction before sending
+    debug_transaction(&client, &tx);
+
+    // Send and confirm transaction
+    let signature = client.send_and_confirm_transaction_with_spinner(&tx)?;
+    println!("Transaction signature: {}", signature);
+
+    // Verify mint account
+    let mint_account = client.get_account(&mint_pda)?;
+    assert_eq!(mint_account.owner, spl_token::ID, "Mint account should be owned by Token program");
+    
+    let mint_data = Mint::unpack(&mint_account.data)?;
+    assert_eq!(mint_data.decimals, 9, "We should have 9 decimals");
+    assert!(mint_data.is_initialized, "Mint should be initialized");
+    assert_eq!(
+        mint_data.mint_authority,
+        COption::Some(mint_pda),
+        "Our PDA should be the mint authority"
+    );
+
+    // Test minting tokens
+    let mint_amount = 1_000_000;
+    
+    let token_account = spl_associated_token_account::get_associated_token_address(
+        &payer.pubkey(),
+        &mint_pda
+    );
+
+    let create_ata_ix = spl_associated_token_account::instruction::create_associated_token_account(
+        &payer.pubkey(),
+        &payer.pubkey(),
+        &mint_pda,
+        &spl_token::id(),
+    );
+
+    let mint_tokens_ix = spl_token::instruction::mint_to(
+        &spl_token::id(),
+        &mint_pda,
+        &token_account,
+        &mint_pda,
+        &[],
+        mint_amount,
+    )?;
+
+    let recent_blockhash = client.get_latest_blockhash()?;
+    
+    let mint_transaction = Transaction::new_signed_with_payer(
+        &[create_ata_ix, mint_tokens_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+
+    let mint_signature = client.send_and_confirm_transaction_with_spinner(&mint_transaction)?;
+    println!("Mint transaction signature: {}", mint_signature);
+
+    // Verify token account
+    let token_account_info = client.get_account(&token_account)?;
+    let token_account_data = spl_token::state::Account::unpack(&token_account_info.data)?;
+    assert_eq!(token_account_data.amount, mint_amount, "We should have exactly the amount we minted");
+
+    // Verify metadata
+    let metadata_account = client.get_account(&metadata_pda)?;
+    assert_eq!(
+        metadata_account.owner,
+        mpl_token_metadata::ID,
+        "Metadata account should be owned by Token Metadata program"
+    );
+
+    let metadata = Metadata::safe_deserialize(&metadata_account.data)?;
+    assert_eq!(metadata.name.trim_matches(char::from(0)), token_name, "Name should match");
+    assert_eq!(metadata.symbol.trim_matches(char::from(0)), token_symbol, "Symbol should match");
+    assert_eq!(metadata.uri.trim_matches(char::from(0)), token_uri, "URI should match");
+    assert_eq!(metadata.mint, mint_pda, "Metadata should point to our mint");
+    assert_eq!(metadata.update_authority, mint_pda, "PDA should be update authority");
+    assert!(metadata.is_mutable, "Token should be mutable");
+
+    Ok(())
+}
 

--- a/pda-mint-authority/program/tests/test.rs
+++ b/pda-mint-authority/program/tests/test.rs
@@ -1,51 +1,343 @@
 use api::prelude::*;
-use solana_program::hash::Hash;
+use solana_program::{hash::Hash, program_pack::Pack};
 use solana_program_test::{processor, BanksClient, ProgramTest};
-use solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction};
+use solana_sdk::{account::Account, signature::Keypair, signer::Signer, transaction::Transaction, compute_budget::ComputeBudgetInstruction};
+use pda_mint_authority_program::process_instruction;
+use spl_token::state::Mint;
+use solana_program::program_option::COption;
+use mpl_token_metadata::accounts::Metadata;
 use steel::*;
-use api::prelude::TokenInstruction::CreateToken;
+
+// Helper function to get PDA addresses
+fn get_addresses(_mint_seed: &[u8]) -> (Pubkey, Pubkey, u8) {
+    let (mint_pda, bump) = Pubkey::find_program_address(
+        &[MintAuthorityPda::SEED_PREFIX.as_bytes()],  
+        &api::ID
+    );
+    
+    let (metadata_pda, _) = Pubkey::find_program_address(
+        &[
+            b"metadata",
+            mpl_token_metadata::ID.as_ref(),
+            mint_pda.as_ref()
+        ],
+        &mpl_token_metadata::ID
+    );
+    
+    (mint_pda, metadata_pda, bump)
+}
 
 async fn setup() -> (BanksClient, Keypair, Hash) {
     let mut program_test = ProgramTest::new(
-        "pda-mint-authority",
+        "pda_mint_authority_program",
         api::ID,
-        processor!(pda_mint_authority_program::process_instruction),
+        processor!(process_instruction),
     );
+
+    // Add Token Program
+    program_test.add_account(
+        spl_token::id(),
+        Account {
+            lamports: 1_000_000_000,
+            data: vec![],
+            owner: solana_program::bpf_loader_upgradeable::id(), // Use upgradeable loader
+            executable: true,
+            rent_epoch: 0,
+        },
+    );
+
+    // Add Token Metadata Program
+    program_test.add_account(
+        mpl_token_metadata::ID,
+        Account {
+            lamports: 1_000_000_000,
+            data: vec![],
+            owner: solana_program::bpf_loader_upgradeable::id(), // Use upgradeable loader
+            executable: true,
+            rent_epoch: 0,
+        },
+    );
+
     program_test.prefer_bpf(true);
+    
     program_test.start().await
 }
 
-#[tokio::test]
-async fn run_test() {
-    // Setup test
-    let (mut banks, payer, blockhash) = setup().await;
-
-    // Submit initialize transaction.
-    let ix = create_token(
-        payer.pubkey(), "Test_Token".to_string(),
-        "$TEST".to_string(),
-        "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQqGK3diR3Zi-mnOXEaj-3ewmFyRYVxGzVzZw&s".to_string()
-    );
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], blockhash);
-    let res = banks.process_transaction(tx).await;
-    assert!(res.is_ok());
-
-    // Verify counter was initialized.
-    let mint_address = mint_pda().0;
-    let mint_account = banks.get_account(mint_address).await.unwrap().unwrap();
-    // let counter = CreateToken::try_from_bytes(&mint_account.data).unwrap();
-    assert_eq!(mint_account.owner, api::ID);
-    // assert_eq!(counter.value, 0);
-
-    // Submit add transaction.
-    let ix = mint_token(payer.pubkey(), 42);
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], blockhash);
-    let res = banks.process_transaction(tx).await;
-    assert!(res.is_ok());
-
-    // Verify counter was incremented.
-    let counter_account = banks.get_account(counter_address).await.unwrap().unwrap();
-    let counter = Counter::try_from_bytes(&counter_account.data).unwrap();
-    assert_eq!(counter.value, 42);
+async fn verify_program_deployment(banks_client: &mut BanksClient, program_id: Pubkey) {
+    if let Ok(Some(program)) = banks_client.get_account(program_id).await {
+        println!("Program found: {:?}", program_id);
+        println!("Program owner: {:?}", program.owner);
+        println!("Program executable: {}", program.executable);
+    } else {
+        eprintln!("Program not found: {:?}", program_id);
+    }
 }
+
+async fn debug_transaction_accounts(banks: &mut BanksClient, tx: &Transaction) {
+    println!("\n=== Transaction Debug Info ===");
+    println!("Number of signatures: {}", tx.signatures.len());
+    println!("Signing pubkeys: {:?}", tx.message.header.num_required_signatures);
+    println!("Readonly signers: {:?}", tx.message.header.num_readonly_signed_accounts);
+    println!("Readonly non-signers: {:?}", tx.message.header.num_readonly_unsigned_accounts);
+    
+    // Print account info for each account in transaction
+    for (i, acc) in tx.message.account_keys.iter().enumerate() {
+        if let Ok(Some(account)) = banks.get_account(*acc).await {
+            println!("\nAccount #{}: {:?}", i, acc);
+            println!("  Owner: {:?}", account.owner);
+            println!("  Lamports: {}", account.lamports);
+            println!("  Executable: {}", account.executable);
+            println!("  Data len: {}", account.data.len());
+            println!("  Is signer: {}", tx.message.is_signer(i));
+            println!("  Is writable: {}", tx.message.is_writable(i));
+        } else {
+            println!("\nAccount #{}: {:?} (not found - will be created)", i, acc);
+        }
+    }
+    println!("\nInstruction Data:");
+    for (i, inst) in tx.message.instructions.iter().enumerate() {
+        println!("Instruction #{}", i);
+        println!("  Program ID: {:?}", tx.message.account_keys[inst.program_id_index as usize]);
+        println!("  Input accounts: {:?}", inst.accounts);
+        println!("  Data: {:?}", inst.data);
+    }
+    println!("===========================\n");
+}
+
+#[tokio::test]
+async fn test_create_token() {
+    // First, let's set up our test environment with a fake Solana network
+    let (mut banks, payer, recent_blockhash) = setup().await;
+
+    // Verify token program exists
+    println!("\n=== Token Program Verification ===");
+    if let Ok(Some(token_program)) = banks.get_account(spl_token::id()).await {
+        println!("Token Program Details:");
+        println!("  Owner: {}", token_program.owner);
+        println!("  Executable: {}", token_program.executable);
+        println!("  Data length: {}", token_program.data.len());
+        println!("  Lamports: {}", token_program.lamports);
+    } else {
+        println!("Token Program not found!");
+    }
+
+    // Let's make sure all our programs are properly deployed and ready to go
+    println!("Verifying your program...");
+    verify_program_deployment(&mut banks, api::ID).await;
+
+    // We need the Token Metadata program for NFT stuff
+    println!("Verifying Token Metadata program...");
+    verify_program_deployment(&mut banks, mpl_token_metadata::ID).await;
+
+    // And of course, the standard SPL Token program
+    println!("Verifying SPL Token program...");
+    verify_program_deployment(&mut banks, spl_token::id()).await;
+    
+    // Set up some basic info for our test token
+    let token_name = "Test".to_string();
+    let token_symbol = "TST".to_string();
+    let token_uri = "https://test.json".to_string();  // This could be metadata JSON in a real token
+    
+    // Generate our PDAs - these are special addresses that our program controls
+    let (mint_pda, metadata_pda, bump) = get_addresses(MintAuthorityPda::SEED_PREFIX.as_bytes());
+
+    println!("\n=== PDA Info ===");
+    println!("Mint PDA: {}", mint_pda);
+    println!("Metadata PDA: {}", metadata_pda);
+    println!("Bump: {}", bump);
+
+    // Create the instruction that will set up our new token
+    let create_token_ix = create_token(
+        payer.pubkey(),
+        token_name.clone(),
+        token_symbol.clone(),
+        token_uri.clone()
+    );
+
+    println!("Accounts in instruction:");
+    println!("1. Payer: {}", payer.pubkey());
+    println!("2. Mint Account: {}", mint_pda);
+    println!("3. Mint Authority: {}", mint_pda);
+    println!("4. Metadata Account: {}", metadata_pda);
+
+    println!("\n=== Transaction Signing Info ===");
+    println!("Payer (signer): {}", payer.pubkey());
+    println!("Mint Authority (PDA, not a signer): {}", mint_pda);
+
+    let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(400_000);  // Increased from default 200k
+    let set_price_ix = ComputeBudgetInstruction::set_compute_unit_price(1);
+    
+    // Build and send our transaction - only need payer to sign since PDAs are handled inside the program
+    let tx = Transaction::new_signed_with_payer(
+        &[        
+        compute_budget_ix,
+        set_price_ix,
+        create_token_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+
+
+    // Add detailed debugging before processing
+    debug_transaction_accounts(&mut banks, &tx).await;
+
+    // Try to process the transaction and catch any errors
+    let result = banks.process_transaction(tx.clone()).await;
+
+    println!("\n=== Signer Analysis ===");
+    println!("Transaction requires {} signatures", tx.message.header.num_required_signatures);
+    println!("Actual signer: {}", payer.pubkey());
+    println!("Expected mint authority (PDA): {}", mint_pda);
+
+    // If something goes wrong, let's get detailed error info to help debug
+    if let Err(err) = &result {
+        
+        println!("Transaction failed with error: {:?}", err);
+
+        // Get transaction status and logs - super helpful for debugging
+        match banks.get_transaction_status(tx.signatures[0]).await {
+            Ok(Some(tx_status)) => {
+                println!("Transaction status: {:?}", tx_status.confirmation_status);
+                if let Some(logs) = tx_status.err {
+                    println!("Transaction logs: {}", logs);
+                } else {
+                    eprintln!("No logs available for this transaction.");
+                }
+            }
+            Ok(None) => println!("Transaction not found or not yet confirmed."),
+            Err(fetch_err) => eprintln!("Failed to get transaction status: {:?}", fetch_err),
+        }
+    }
+    
+    // Make sure our transaction succeeded
+    assert!(result.is_ok(), "Failed to process transaction: {:?}", result.err());
+
+    // Now let's check if our mint account was created correctly
+    let mint_account = banks.get_account(mint_pda).await.unwrap().unwrap();
+    assert_eq!(mint_account.owner, spl_token::ID, "Mint account should be owned by Token program");
+    
+    // Parse the mint account data and verify everything looks good
+    let mint_data = Mint::unpack(&mint_account.data).unwrap();
+    assert_eq!(mint_data.decimals, 9, "We should have 9 decimals");
+    assert!(mint_data.is_initialized, "Mint should be initialized");
+    assert_eq!(
+        mint_data.mint_authority,
+        COption::Some(mint_pda),
+        "Our PDA should be the mint authority"
+    );
+    
+    // Now for the fun part - let's try minting some tokens!
+    let mint_amount = 1_000_000;  // Let's mint a million tokens
+    
+    // Figure out where we're going to send these tokens
+    let token_account = spl_associated_token_account::get_associated_token_address(
+        &payer.pubkey(),
+        &mint_pda
+    );
+
+    // First we need to create a token account to hold our new tokens
+    let create_ata_ix = spl_associated_token_account::instruction::create_associated_token_account(
+        &payer.pubkey(),  // payer
+        &payer.pubkey(),  // wallet that will own the tokens
+        &mint_pda,        // which token type
+        &spl_token::id(), // token program
+    );
+
+    // Now create the instruction to mint our tokens
+    let mint_tokens_ix = spl_token::instruction::mint_to(
+        &spl_token::id(),
+        &mint_pda,       // mint account
+        &token_account,  // where to send the tokens
+        &mint_pda,       // PDA as mint authority
+        &[],            // no extra signers needed
+        mint_amount,    // how many tokens to mint
+    ).unwrap();
+
+    // Bundle it all together in a transaction
+    let mint_transaction = Transaction::new_signed_with_payer(
+        &[create_ata_ix, mint_tokens_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+
+    // Send it off!
+    let mint_result = banks.process_transaction(mint_transaction).await;
+    assert!(mint_result.is_ok(), "Failed to mint tokens: {:?}", mint_result.err());
+
+    // Make sure our tokens arrived
+    let token_account_info = banks.get_account(token_account).await.unwrap().unwrap();
+    let token_account_data = spl_token::state::Account::unpack(&token_account_info.data).unwrap();
+    assert_eq!(token_account_data.amount, mint_amount, "We should have exactly the amount we minted");
+    
+    // Check if our metadata got created properly
+    let metadata_account = banks.get_account(metadata_pda).await.unwrap().unwrap();
+    assert_eq!(
+        metadata_account.owner,
+        mpl_token_metadata::ID,
+        "Metadata account should be owned by Token Metadata program"
+    );
+    
+    // Parse and verify all our metadata
+    let metadata = Metadata::safe_deserialize(&metadata_account.data).expect("Failed to deserialize metadata");
+    assert_eq!(metadata.name.trim_matches(char::from(0)), token_name, "Name should match");
+    assert_eq!(metadata.symbol.trim_matches(char::from(0)), token_symbol, "Symbol should match");
+    assert_eq!(metadata.uri.trim_matches(char::from(0)), token_uri, "URI should match");
+    assert_eq!(metadata.mint, mint_pda, "Metadata should point to our mint");
+    assert_eq!(metadata.update_authority, mint_pda, "PDA should be update authority");
+    assert!(metadata.is_mutable, "Token should be mutable");
+    
+    // Now let's try some things that should fail
+    
+    // Try making another token with the same PDA (should fail)
+    let result = banks
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[create_token(
+                payer.pubkey(),
+                "Dup".to_string(),
+                "DUP".to_string(),
+                "https://dup.json".to_string(),
+            )],
+            Some(&payer.pubkey()),
+            &[&payer],
+            recent_blockhash,
+        ))
+        .await;
+    assert!(result.is_err(), "Shouldn't be able to reuse the same PDA");
+
+    // Try creating a token with no name (should fail)
+    let result = banks
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[create_token(
+                payer.pubkey(),
+                "".to_string(),
+                "TST".to_string(),
+                token_uri.clone(),
+            )],
+            Some(&payer.pubkey()),
+            &[&payer],
+            recent_blockhash,
+        ))
+        .await;
+    assert!(result.is_err(), "Shouldn't allow tokens with no name");
+
+    // Try creating a token without proper signing authority
+    let non_signer = Keypair::new();
+    let result = banks
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[create_token(
+                non_signer.pubkey(),  // Using a key we don't have signing rights for
+                token_name.clone(),
+                token_symbol.clone(),
+                token_uri.clone(),
+            )],
+            Some(&payer.pubkey()),
+            &[&payer],  // Notice we don't have non_signer's signature
+            recent_blockhash,
+        ))
+        .await;
+    assert!(result.is_err(), "Should fail if the authority didn't actually sign");
+}
+
 

--- a/token-swap/Cargo.lock
+++ b/token-swap/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "aquamarine"
@@ -383,7 +383,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -580,7 +580,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "syn_derive",
 ]
 
@@ -697,7 +697,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1044,7 +1044,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1055,7 +1055,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1182,7 +1182,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1205,7 +1205,7 @@ checksum = "a6cbae11b3de8fce2a456e8ea3dada226b35fe791f0dc1d360c0941f0bb681f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1281,9 +1281,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -1305,7 +1305,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1318,7 +1318,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1476,7 +1476,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1590,34 +1590,6 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.12",
  "tracing",
-]
-
-[[package]]
-name = "hand-api"
-version = "0.1.0"
-dependencies = [
- "bytemuck",
- "lever-api",
- "num_enum 0.7.3",
- "solana-program",
- "steel",
- "thiserror",
-]
-
-[[package]]
-name = "hand-program"
-version = "0.1.0"
-dependencies = [
- "bs64",
- "hand-api",
- "lever-api",
- "lever-program",
- "rand 0.8.5",
- "solana-program",
- "solana-program-test",
- "solana-sdk",
- "steel",
- "tokio",
 ]
 
 [[package]]
@@ -1995,26 +1967,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lever-api"
-version = "0.1.0"
-dependencies = [
- "bytemuck",
- "num_enum 0.7.3",
- "solana-program",
- "steel",
- "thiserror",
-]
-
-[[package]]
-name = "lever-program"
-version = "0.1.0"
-dependencies = [
- "lever-api",
- "solana-program",
- "steel",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,7 +2318,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2447,7 +2399,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2459,7 +2411,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2625,29 +2577,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -2795,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2819,7 +2771,7 @@ checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3002,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3262,7 +3214,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3315,9 +3267,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
@@ -3333,13 +3285,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3385,7 +3337,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3868,7 +3820,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4374,7 +4326,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4716,7 +4668,7 @@ checksum = "07fd7858fc4ff8fb0e34090e41d7eb06a823e1057945c26d480bfc21d2338a93"
 dependencies = [
  "quote",
  "spl-discriminator-syn",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4728,7 +4680,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.8",
- "syn 2.0.82",
+ "syn 2.0.85",
  "thiserror",
 ]
 
@@ -4776,7 +4728,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.8",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4971,9 +4923,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4989,7 +4941,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5123,7 +5075,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5134,7 +5086,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "test-case-core",
 ]
 
@@ -5155,22 +5107,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5249,10 +5201,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "token-swap-api"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "num_enum 0.7.3",
+ "solana-program",
+ "steel",
+ "thiserror",
+]
+
+[[package]]
+name = "token-swap-program"
+version = "0.1.0"
+dependencies = [
+ "bs64",
+ "rand 0.8.5",
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+ "steel",
+ "token-swap-api",
+ "tokio",
+]
+
+[[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5274,7 +5251,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5420,7 +5397,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5658,7 +5635,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -5692,7 +5669,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6000,7 +5977,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6020,7 +5997,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]


### PR DESCRIPTION
There are two types of tests for pda-mint-authority:
1. BanksClient
2. RpcClient on Devnet

BanksClient is for local testing purposes. However, the spl_token program needs to be deployed in the local test environment.

RpcClient for Devnet is for devnet testing purposes and few modifications to avoid this error during testing: 
```can call blocking only when running on the multi-threaded runtime```

cpi only has one type of test which is the BanksClient test for both the hand program and the lever program. It can be updated to work for devnet if that is preferable.

Note: You will need to deploy to devnet before running tests in the devnet cluster.